### PR TITLE
Autopopulating the shop & adding new items backend

### DIFF
--- a/plant-crossing/data-structures/Item.ts
+++ b/plant-crossing/data-structures/Item.ts
@@ -1,4 +1,4 @@
-class Item {
+export class Item {
   private name: string; // name of item
   private price: number; // cost of item
 
@@ -16,15 +16,21 @@ class Item {
   }
 }
 
-class ShopItem extends Item {
+export class ShopItem extends Item {
   private itemType: "Plant" | "Seed"; // type of item sold in shop
+  private rarity: Rarity; // rarity of the item
 
-  public constructor(name: string, price: number, itemType: "Plant" | "Seed") {
+  public constructor(name: string, price: number, itemType: "Plant" | "Seed", rarity: Rarity) {
     super(name, price);
     this.itemType = itemType;
+    this.rarity = rarity;
   }
 
   public getItemType() {
     return this.itemType;
+  }
+
+  public getRarity() {
+    return this.rarity;
   }
 }

--- a/plant-crossing/data-structures/Shop.tsx
+++ b/plant-crossing/data-structures/Shop.tsx
@@ -1,14 +1,43 @@
 import Player from "../data-structures/Player";
+import { ShopItem } from "../data-structures/Item";
+import { Rarity, availableItems, rarityWeights } from "../data/items";
+import { weightedRandomSelection } from "../utils/weightedRandom";
 
 class Shop {
   private items: ShopItem[]; // list of items available in the shop
+  private lastUpdated: Date; // timestamp of the last update
 
   public constructor() {
-    this.items = [
-      new ShopItem("Rose Seed", 10, "Seed"),
-      new ShopItem("Cactus Plant", 20, "Plant"),
-      // add more items here, just examples above
-    ];
+    // initialize shop with a random set of 5 items
+    this.items = this.generateRandomItems(5);
+    this.lastUpdated = new Date();
+
+    // set up an interval to update items every 12 hours
+    setInterval(() => {
+      this.refreshItems();
+    }, 12 * 60 * 60 * 1000); // 12 hours in milliseconds
+  }
+
+  // helper method to generate random set of items
+  private generateRandomItems(count: number): ShopItem[] {
+    const selectedItems: ShopItem[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const weights = availableItems.map(
+        (item) => rarityWeights[item.getRarity()]
+      );
+      const randomItem = weightedRandomSelection(availableItems, weights);
+      selectedItems.push(randomItem);
+    }
+
+    return selectedItems;
+  }
+
+  // method to refresh items
+  private refreshItems() {
+    this.items = this.generateRandomItems(5);
+    this.lastUpdated = new Date();
+    console.log("Shop inventory updated at: ", this.lastUpdated);
   }
 
   public getItems() {

--- a/plant-crossing/data/items.ts
+++ b/plant-crossing/data/items.ts
@@ -1,7 +1,7 @@
 // data/items.ts
 import { ShopItem } from '../data-structures/Item';
 
-// Define the Rarity enum
+// define the Rarity enum
 export enum Rarity {
   common,
   rare,
@@ -9,7 +9,7 @@ export enum Rarity {
   legendary,
 }
 
-// Mapping for coin values based on rarity
+// mapping for coin values based on rarity
 export const coinMapping: { [key in Rarity]: number } = {
   [Rarity.common]: 2,
   [Rarity.rare]: 3,
@@ -17,7 +17,7 @@ export const coinMapping: { [key in Rarity]: number } = {
   [Rarity.legendary]: 5,
 };
 
-// Define the weights for rarity
+// define the weights for rarity
 export const rarityWeights: { [key in Rarity]: number } = {
   [Rarity.common]: 50,
   [Rarity.rare]: 30,
@@ -25,11 +25,37 @@ export const rarityWeights: { [key in Rarity]: number } = {
   [Rarity.legendary]: 5,
 };
 
-// Define the list of available items
 export const availableItems = [
-  new ShopItem("Rose Seed", 10, "Seed", Rarity.common),
-  new ShopItem("Cactus Plant", 20, "Plant", Rarity.common),
-  new ShopItem("Orchid Seed", 50, "Seed", Rarity.rare),
-  new ShopItem("Bonsai Plant", 100, "Plant", Rarity.unique),
-  new ShopItem("Golden Lily Plant", 500, "Plant", Rarity.legendary),
-];
+    // common items
+    new ShopItem("Rose Seed", 10, "Seed", Rarity.common),
+    new ShopItem("Rose Plant", 15, "Plant", Rarity.common),
+    new ShopItem("Cactus Seed", 8, "Seed", Rarity.common),
+    new ShopItem("Cactus Plant", 20, "Plant", Rarity.common),
+    new ShopItem("Sunflower Seed", 10, "Seed", Rarity.common),
+    new ShopItem("Sunflower Plant", 18, "Plant", Rarity.common),
+    new ShopItem("Fern Seed", 12, "Seed", Rarity.common),
+    new ShopItem("Fern Plant", 18, "Plant", Rarity.common),
+    new ShopItem("Daisy Seed", 10, "Seed", Rarity.common),
+    new ShopItem("Daisy Plant", 17, "Plant", Rarity.common),
+    new ShopItem("Lavender Seed", 13, "Seed", Rarity.common),
+    new ShopItem("Lavender Plant", 25, "Plant", Rarity.common),
+  
+    // rare items
+    new ShopItem("Orchid Seed", 50, "Seed", Rarity.rare),
+    new ShopItem("Orchid Plant", 75, "Plant", Rarity.rare),
+    new ShopItem("Tulip Seed", 45, "Seed", Rarity.rare),
+    new ShopItem("Tulip Plant", 60, "Plant", Rarity.rare),
+    new ShopItem("Cherry Blossom Seed", 70, "Seed", Rarity.rare),
+    new ShopItem("Cherry Blossom Plant", 90, "Plant", Rarity.rare),
+  
+    // unique items
+    new ShopItem("Bonsai Seed", 90, "Seed", Rarity.unique),
+    new ShopItem("Bonsai Plant", 100, "Plant", Rarity.unique),
+    new ShopItem("Venus Flytrap Seed", 130, "Seed", Rarity.unique),
+    new ShopItem("Venus Flytrap Plant", 150, "Plant", Rarity.unique),
+  
+    // legendary items
+    new ShopItem("Golden Lily Seed", 450, "Seed", Rarity.legendary),
+    new ShopItem("Golden Lily Plant", 500, "Plant", Rarity.legendary),
+  ];
+  

--- a/plant-crossing/data/items.ts
+++ b/plant-crossing/data/items.ts
@@ -1,0 +1,35 @@
+// data/items.ts
+import { ShopItem } from '../data-structures/Item';
+
+// Define the Rarity enum
+export enum Rarity {
+  common,
+  rare,
+  unique,
+  legendary,
+}
+
+// Mapping for coin values based on rarity
+export const coinMapping: { [key in Rarity]: number } = {
+  [Rarity.common]: 2,
+  [Rarity.rare]: 3,
+  [Rarity.unique]: 4,
+  [Rarity.legendary]: 5,
+};
+
+// Define the weights for rarity
+export const rarityWeights: { [key in Rarity]: number } = {
+  [Rarity.common]: 50,
+  [Rarity.rare]: 30,
+  [Rarity.unique]: 15,
+  [Rarity.legendary]: 5,
+};
+
+// Define the list of available items
+export const availableItems = [
+  new ShopItem("Rose Seed", 10, "Seed", Rarity.common),
+  new ShopItem("Cactus Plant", 20, "Plant", Rarity.common),
+  new ShopItem("Orchid Seed", 50, "Seed", Rarity.rare),
+  new ShopItem("Bonsai Plant", 100, "Plant", Rarity.unique),
+  new ShopItem("Golden Lily Plant", 500, "Plant", Rarity.legendary),
+];

--- a/plant-crossing/utils/weightedRandom.ts
+++ b/plant-crossing/utils/weightedRandom.ts
@@ -1,0 +1,25 @@
+import { ShopItem } from '../data-structures/Item';
+
+// helper function to randomly pick an item based on weights
+export function weightedRandomSelection(items: ShopItem[], weights: number[]): ShopItem {
+  const cumulativeWeights: number[] = [];
+  let sum = 0;
+
+  // create cumulative weight array
+  for (let i = 0; i < weights.length; i++) {
+    sum += weights[i];
+    cumulativeWeights[i] = sum;
+  }
+
+  // get a random number in the range of 0 to sum
+  const random = Math.random() * sum;
+
+  // find the item that corresponds to this random number
+  for (let i = 0; i < cumulativeWeights.length; i++) {
+    if (random < cumulativeWeights[i]) {
+      return items[i];
+    }
+  }
+
+  return items[items.length - 1]; // fallback to the last item
+}


### PR DESCRIPTION
- Expanded the list of available shop items with more seeds and plants
- Added an auto-populating feature to refresh the shop inventory every 12 hours
- Randomized shop items using a weighted selection based on rarity to favor less rare items