### PR TITLE
Added inventory screen with sample items [frontend]

### DIFF
--- a/plant-crossing/screens/GardenScreen.tsx
+++ b/plant-crossing/screens/GardenScreen.tsx
@@ -1,10 +1,71 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, FlatList, TouchableOpacity } from 'react-native';
+
+  type InvItemProps = {
+    item: InvItemData;
+    onPress: () => void;
+    backgroundColor: string;
+    textColor: string;
+  };
+
+  type InvItemData = {
+    id: string;
+    title: string;
+  };
+
+  // TODO: replace this with inventory data structure
+  const DATA: InvItemData[] = [
+    {
+      id: '1',
+      title: 'First Item',
+    },
+    {
+      id: '2',
+      title: 'Second Item',
+    },
+    {
+      id: '3',
+      title: 'Third Item',
+    },
+  ];
+  
+  const InvItem = ({item, onPress, backgroundColor, textColor}: InvItemProps) => (
+    <TouchableOpacity onPress={onPress} style={[styles.invItem, {backgroundColor}]}>
+      <Text style={[styles.invText, {color: textColor}]}>{item.title}</Text>
+    </TouchableOpacity>
+  );
 
 export default function GardenScreen() {
+
+  const [selectedId, setSelectedId] = useState<string>();
+
+  const renderItem = ({item}: {item: InvItemData}) => {
+    const backgroundColor = item.id === selectedId ? '#8ba286' : '#d1dbcd';
+    const color = item.id === selectedId ? 'white' : 'black';
+
+    return (
+      <InvItem
+        item={item}
+        onPress={() => setSelectedId(item.id)}
+        backgroundColor={backgroundColor}
+        textColor={color}
+      />
+    );
+  };
+
   return (
     <View style={styles.container}>
-      <Text style={styles.bigText}>Garden Page</Text>
+      <Text style={styles.title}>Garden Page</Text>
+      <Text style={styles.gardenSection}>placeholder</Text>
+      <FlatList
+          style={styles.inventorySection}
+          data={DATA}
+          renderItem={renderItem}
+          keyExtractor={item => item.id}
+          extraData={selectedId}
+          horizontal={true}
+        />
       <StatusBar style="auto" />
     </View>
   );
@@ -17,8 +78,26 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  bigText: {
-    fontSize: 50, // You can increase this value to make the text even bigger
+  title: {
+    fontSize: 24,
     fontWeight: 'bold',
   },
+  gardenSection: {
+    flex: 3,
+  },
+  inventorySection: {
+    flex: 1,
+    backgroundColor: '#ededed',
+  },
+  invItem: {
+    backgroundColor: '#d1dbcd', // #d1dbcd
+    padding: 20,
+    width: 150,
+    marginVertical: 16,
+    marginHorizontal: 16,
+  },
+  invText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  }
 });

--- a/plant-crossing/yarn.lock
+++ b/plant-crossing/yarn.lock
@@ -3803,11 +3803,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -4669,11 +4664,6 @@ lighthouse-logger@^1.0.0:
   dependencies:
     debug "^2.6.9"
     marky "^1.2.2"
-
-lightningcss-darwin-arm64@1.19.0:
-  version "1.19.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.19.0.tgz"
-  integrity sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==
 
 lightningcss@~1.19.0:
   version "1.19.0"


### PR DESCRIPTION
On the garden screen, a new inventory bottom bar is now visible. It holds three example items which currently have no functionality. It can be horizontally scrolled and the items turn a different color when selected (though it can't be unselected).

Demo of inventory bar: (https://github.com/user-attachments/assets/1ef7af96-9f39-4355-b020-ebc76efed231)

Demo of inventory bar after horizontally scrolled and an item has been clicked: (https://github.com/user-attachments/assets/2393c87f-1624-4fcf-af0f-b7fc207a2d63)

Next Steps:
- Use the player seed/plant inventory data structure as the DATA to be shown. Update itemProps and itemData as necessary to use all the seed info needed. 
    - Current idea/plan: Use firebase/user auth to find CurrentUser and use that as the Player, then get the inv with Player.getSeedInventory(). Depends on #29, uses data structures from #1 
- Potentially add a button at the bottom of the garden screen that will pull up this inventory list, instead of having it always visible
- Potentially make Inventory into its own screen/separate file so as to keep files short and concise
